### PR TITLE
Set upstream metadata fields: Bug-Database, Bug-Submit, Repository, Repository-Browse

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+rumur (2020.04.26-2) UNRELEASED; urgency=medium
+
+  * Set upstream metadata fields: Bug-Database, Bug-Submit, Repository,
+    Repository-Browse.
+
+ -- Debian Janitor <janitor@jelmer.uk>  Tue, 05 May 2020 05:27:37 +0000
+
 rumur (2020.04.26-1) unstable; urgency=medium
 
   * New upstream release.

--- a/debian/upstream/metadata
+++ b/debian/upstream/metadata
@@ -1,0 +1,4 @@
+Bug-Database: https://github.com/Smattr/rumur/issues
+Bug-Submit: https://github.com/Smattr/rumur/issues/new
+Repository: https://github.com/Smattr/rumur.git
+Repository-Browse: https://github.com/Smattr/rumur


### PR DESCRIPTION
Set upstream metadata fields: Bug-Database, Bug-Submit, Repository, Repository-Browse. ([upstream-metadata-file-is-missing](https://lintian.debian.org/tags/upstream-metadata-file-is-missing.html), [upstream-metadata-missing-bug-tracking](https://lintian.debian.org/tags/upstream-metadata-missing-bug-tracking.html), [upstream-metadata-missing-repository](https://lintian.debian.org/tags/upstream-metadata-missing-repository.html))

This merge proposal was created automatically by the [Janitor bot](https://janitor.debian.net/lintian-fixes).

You can follow up to this merge proposal as you normally would.

Build and test logs for this branch can be found at
https://janitor.debian.net/lintian-fixes/pkg/rumur/833641ef-1c72-4b11-b4c8-c50068ae5daa.


## Debdiff

These changes affect the binary packages:


[The following lists of changes regard files as different if they have
different names, permissions or owners.]
### Files in second set of .debs but not in first
    -rw-r--r--  root/root   /usr/lib/debug/.build-id/0b/764afaca8c45fdb64ff1470fed070d08b61018.debug
    -rw-r--r--  root/root   /usr/lib/debug/.build-id/33/980ea285762b89834137fb0abf84a105306b0e.debug
    -rw-r--r--  root/root   /usr/lib/debug/.build-id/45/ee056e3dca511ffe61a3a0923e32cdd764fa16.debug
    -rw-r--r--  root/root   /usr/lib/debug/.build-id/9f/2789d375087e944f3819d7817fd043e75143eb.debug
### Files in first set of .debs but not in second
    -rw-r--r--  root/root   /usr/lib/debug/.build-id/2f/d7b23b325ef8feb9afa4c2770ff4cc5cd9e0c1.debug
    -rw-r--r--  root/root   /usr/lib/debug/.build-id/43/ee60f03748b8c46979dcbc313307f65d060a76.debug
    -rw-r--r--  root/root   /usr/lib/debug/.build-id/48/3ff683eaa6e58b30236faa79a88dc3fc26e54c.debug
    -rw-r--r--  root/root   /usr/lib/debug/.build-id/63/2542207c674767085995c6c28e7bcb8b7c5a8f.debug

No differences were encountered between the control files of package \*\*rumur\*\*
### Control files of package rumur-dbgsym: lines which differ (wdiff format)
* Build-Ids: [-2fd7b23b325ef8feb9afa4c2770ff4cc5cd9e0c1 43ee60f03748b8c46979dcbc313307f65d060a76 483ff683eaa6e58b30236faa79a88dc3fc26e54c 632542207c674767085995c6c28e7bcb8b7c5a8f-] {+0b764afaca8c45fdb64ff1470fed070d08b61018 33980ea285762b89834137fb0abf84a105306b0e 45ee056e3dca511ffe61a3a0923e32cdd764fa16 9f2789d375087e944f3819d7817fd043e75143eb+}


You can also view the [diffoscope diff](https://janitor.debian.net/api/run/833641ef-1c72-4b11-b4c8-c50068ae5daa/diffoscope?filter_boring=1) ([unfiltered](https://janitor.debian.net/api/run/833641ef-1c72-4b11-b4c8-c50068ae5daa/diffoscope)).
