### PR TITLE
use check* Python functions instead of run when check=True

### DIFF
--- a/tests/comment-parsing.py
+++ b/tests/comment-parsing.py
@@ -112,9 +112,8 @@ end;
 '''
 
 def process(input: str) -> str:
-  proc = subprocess.run(['murphi-comment-ls'], input=input,
-    stdout=subprocess.PIPE, check=True, universal_newlines=True)
-  return proc.stdout
+  return subprocess.check_output(['murphi-comment-ls'], input=input,
+    universal_newlines=True)
 
 def main():
 


### PR DESCRIPTION
Consulting the Python docs, I realise I had the misunderstanding that the
`input` parameter is only available for `run`. It is actually also available for
`check_call` and `check_output`; in the case of the latter, as far back as
Python 3.4. With that in mind, I have to disagree with the Python docs:

  The recommended approach to invoking subprocesses is to use the run() function
  for all use cases it can handle.

As soon as you are passing `check=True`, the `check*` functions are both fewer
characters and more backwards compatible.