### PR TITLE
setup Linux GCC 10.3 testing on Cirrus

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -20,6 +20,13 @@ task:
         image_family: freebsd-11-3-snap
       install_script: pkg upgrade -y && pkg install -y bash bison cmake gmp libxml2 z3
 
+    - name: Linux, GCC 10.3
+      container:
+        image: gcc:10.3
+      environment:
+        DDEBIAN_FRONTEND: noninteractive
+      install_script: apt-get update -y && apt-get install --no-install-recommends -y bison cmake flex libfl-dev libgmp-dev
+
     - name: macOS, XCode 11.3.1, Homebrew
       osx_instance:
         image: catalina-xcode-11.3.1


### PR DESCRIPTION
The generosity of Travis CI finally ran out last year, and no new Travis jobs
will run. This change is the first step to migrating the .travis.yml content to
.cirrus.yml. What I have discovered so far in the way of advantages and
disadvantages:

  1. The Cirrus runners are *much* more powerful than the Travis runners. I do
     not have exact numbers, but it feels like the Cirrus runners take ~15mins
     to do work that takes the Travis runners ~1hr. Cirrus is backed by Google
     Compute Project (GCP), while I do not know what backs Travis. It is
     possible it is also GCP, but they just put your jobs on a lower tier.

  2. Cirrus has a job timeout of 2hrs vs 50mins on Travis. I am hoping this will
     let us drop the extremely painful test sharding and just have a single test
     job per platform.

  3. Cirrus seems to have no support for (1) specific Linux distros or (2)
     architectures other than x86-64. I think we will just have to live with
     this loss of coverage going forwards. To be fair, the Travis multi-arch
     support was a joke, with the runners rarely if ever starting up correctly.