### PR TITLE
enable XML linting and SMT solving in GCC 10 CI job

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -25,7 +25,7 @@ task:
         image: gcc:10.3
       environment:
         DDEBIAN_FRONTEND: noninteractive
-      install_script: apt-get update -y && apt-get install --no-install-recommends -y bison cmake libfl-dev libgmp-dev
+      install_script: apt-get update -y && apt-get install --no-install-recommends -y bison cmake libfl-dev libgmp-dev libxml2-utils z3
 
     - name: macOS, XCode 11.3.1, Homebrew
       osx_instance:


### PR DESCRIPTION
Without these enabled, the job completes in ~17mins. So it looks feasible to
enable both of these.