### PR TITLE
move FreeBSD testing to 12.2

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -11,9 +11,9 @@ task:
       freebsd_instance:
         image_family: freebsd-13-0-snap
       install_script: pkg upgrade -y && pkg install -y bash bison cmake gmp libxml2 z3
-    - name: FreeBSD 12.1
+    - name: FreeBSD 12.2
       freebsd_instance:
-        image_family: freebsd-12-1-snap
+        image_family: freebsd-12-2-snap
       install_script: pkg upgrade -y && pkg install -y bash bison cmake gmp libxml2 z3
     - name: FreeBSD 11.3
       freebsd_instance:


### PR DESCRIPTION
The FreeBSD 12.1 snap seems no longer bootable (and has not been so for some
time). This is perhaps unsurprising as 12.1 was EOLed in January 2021.¹

¹ https://www.freebsd.org/security/unsupported/