### PR TITLE
CI: use a cmake.org URL to retrieve CMake instead of github.com

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -31,8 +31,8 @@ task:
         image: gcc:4.9
       environment:
         DEBIAN_FRONTEND: noninteractive
-        PATH: /opt/cmake-3.21.0-rc3-linux-x86_64/bin:${PATH}
-      install_script: apt-get update -y && apt-get install --no-install-recommends -y bison flex libgmp-dev python3 && wget https://github.com/Kitware/CMake/releases/download/v3.21.0-rc3/cmake-3.21.0-rc3-linux-x86_64.tar.gz && mkdir -p /opt && tar xvf cmake-3.21.0-rc3-linux-x86_64.tar.gz --directory /opt
+        PATH: /opt/cmake-3.22.0-linux-x86_64/bin:${PATH}
+      install_script: apt-get update -y && apt-get install --no-install-recommends -y bison flex libgmp-dev python3 && wget https://cmake.org/files/v3.22/cmake-3.22.0-linux-x86_64.tar.gz && mkdir -p /opt && tar xvf cmake-3.22.0-linux-x86_64.tar.gz --directory /opt
     - name: Linux, GCC 8.5
       container:
         image: gcc:8.5


### PR DESCRIPTION
Github seems to now require authentication for release asset links, so CI was
when attempting to fetch this.