### PR TITLE
CI: upgrade macOS testing environments

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -56,9 +56,9 @@ task:
         UBSAN_OPTIONS: print_stacktrace=1
       install_script: apt-get update -y && apt-get install --no-install-recommends -y bison cmake libfl-dev libgmp-dev libxml2-utils strace z3
 
-    - name: macOS, XCode 11.3.1, Homebrew
+    - name: macOS, XCode 13.1, Homebrew
       osx_instance:
-        image: catalina-xcode-11.3.1
+        image: monterey-xcode-13.1
       environment:
         # To quote Homebrew, "bison is keg-only, which means it was not
         # symlinked into /usr/local, because some formulae require a newer
@@ -70,80 +70,24 @@ task:
       # the flags/features we use. To install newer versions and make them
       # available to CMake we need to link them into the system directories.
       install_script: brew update && brew install bison && brew link bison --force
-    - name: macOS, XCode 11.4.1, Homebrew
+    - name: macOS, XCode 13.2, Homebrew
       osx_instance:
-        image: catalina-xcode-11.4.1
-      environment:
-        PATH: /usr/local/opt/bison/bin:${PATH}
-        CXXFLAGS: -fsanitize=address -Werror
-      install_script: brew update && brew install bison && brew link bison --force
-    - name: macOS, XCode 11.5, Homebrew
-      osx_instance:
-        image: catalina-xcode-11.5
-      environment:
-        PATH: /usr/local/opt/bison/bin:${PATH}
-        CXXFLAGS: -fsanitize=address -Werror
-      install_script: brew update && brew install bison && brew link bison --force
-    - name: macOS, XCode 11.6, Homebrew
-      osx_instance:
-        image: catalina-xcode-11.6
-      environment:
-        PATH: /usr/local/opt/bison/bin:${PATH}
-        CXXFLAGS: -fsanitize=address -Werror
-      install_script: brew update && brew install bison && brew link bison --force
-    - name: macOS, XCode 12.0, Homebrew
-      osx_instance:
-        image: catalina-xcode-12.0
-      environment:
-        PATH: /usr/local/opt/bison/bin:${PATH}
-        CXXFLAGS: -fsanitize=address -Werror
-      install_script: brew update && brew install bison && brew link bison --force
-    - name: macOS, XCode 12.1, Homebrew
-      osx_instance:
-        image: catalina-xcode-12.1
+        image: monterey-xcode-13.2
       environment:
         PATH: /usr/local/opt/bison/bin:${PATH}
         CXXFLAGS: -fsanitize=address -Werror
       install_script: brew update && brew install bison && brew link bison --force
 
-    - name: macOS, XCode 11.3.1, Macports
+    - name: macOS, XCode 13.1, Macports
       osx_instance:
-        image: catalina-xcode-11.3.1
+        image: monterey-xcode-13.1
       environment:
         PATH: /opt/local/bin:${PATH}
         CXXFLAGS: -fsanitize=address -Werror
       install_script: ./misc/install-macports.sh && sudo port -v selfupdate && sudo port -N install bison
-    - name: macOS, XCode 11.4.1, Macports
+    - name: macOS, XCode 13.2, Macports
       osx_instance:
-        image: catalina-xcode-11.4.1
-      environment:
-        PATH: /opt/local/bin:${PATH}
-        CXXFLAGS: -fsanitize=address -Werror
-      install_script: ./misc/install-macports.sh && sudo port -v selfupdate && sudo port -N install bison
-    - name: macOS, XCode 11.5, Macports
-      osx_instance:
-        image: catalina-xcode-11.5
-      environment:
-        PATH: /opt/local/bin:${PATH}
-        CXXFLAGS: -fsanitize=address -Werror
-      install_script: ./misc/install-macports.sh && sudo port -v selfupdate && sudo port -N install bison
-    - name: macOS, XCode 11.6, Macports
-      osx_instance:
-        image: catalina-xcode-11.6
-      environment:
-        PATH: /opt/local/bin:${PATH}
-        CXXFLAGS: -fsanitize=address -Werror
-      install_script: ./misc/install-macports.sh && sudo port -v selfupdate && sudo port -N install bison
-    - name: macOS, XCode 12.0, Macports
-      osx_instance:
-        image: catalina-xcode-12.0
-      environment:
-        PATH: /opt/local/bin:${PATH}
-        CXXFLAGS: -fsanitize=address -Werror
-      install_script: ./misc/install-macports.sh && sudo port -v selfupdate && sudo port -N install bison
-    - name: macOS, XCode 12.1, Macports
-      osx_instance:
-        image: catalina-xcode-12.1
+        image: monterey-xcode-13.2
       environment:
         PATH: /opt/local/bin:${PATH}
         CXXFLAGS: -fsanitize=address -Werror


### PR DESCRIPTION
Cirrus seems to have dropped support for macOS Catalina (10?). It is claimed to
be officially supported¹ but jobs on it simply stall forever. For Rumur, it is
fine to migrate to newer macOS as we only really support whatever is the latest
macOS.

¹ https://cirrus-ci.org/guide/macOS/