### PR TITLE
allow 'newfstatat' in the sandbox

### DIFF
--- a/rumur/resources/header.c
+++ b/rumur/resources/header.c
@@ -223,6 +223,10 @@ static void sandbox(void) {
         BPF_JUMP(BPF_JMP | BPF_JEQ | BPF_K, __NR_fstat64, 0, 1),
         BPF_STMT(BPF_RET | BPF_K, SECCOMP_RET_ALLOW),
 #endif
+#ifdef __NR_newfstatat
+        BPF_JUMP(BPF_JMP | BPF_JEQ | BPF_K, __NR_newfstatat, 0, 1),
+        BPF_STMT(BPF_RET | BPF_K, SECCOMP_RET_ALLOW),
+#endif
 #ifdef __NR_write
         BPF_JUMP(BPF_JMP | BPF_JEQ | BPF_K, __NR_write, 0, 1),
         BPF_STMT(BPF_RET | BPF_K, SECCOMP_RET_ALLOW),


### PR DESCRIPTION
Newer kernels/libc use this in preference to `stat`/`fstat`.

Reported-by: Lucas Nussbaum <lucas@debian.org>

Debian: #1002186 “rumur: FTBFS”
  https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1002186