### PR TITLE
allow 'statx' in the sandbox

### DIFF
--- a/rumur/resources/header.c
+++ b/rumur/resources/header.c
@@ -227,6 +227,10 @@ static void sandbox(void) {
         BPF_JUMP(BPF_JMP | BPF_JEQ | BPF_K, __NR_newfstatat, 0, 1),
         BPF_STMT(BPF_RET | BPF_K, SECCOMP_RET_ALLOW),
 #endif
+#ifdef __NR_statx
+        BPF_JUMP(BPF_JMP | BPF_JEQ | BPF_K, __NR_statx, 0, 1),
+        BPF_STMT(BPF_RET | BPF_K, SECCOMP_RET_ALLOW),
+#endif
 #ifdef __NR_write
         BPF_JUMP(BPF_JMP | BPF_JEQ | BPF_K, __NR_write, 0, 1),
         BPF_STMT(BPF_RET | BPF_K, SECCOMP_RET_ALLOW),


### PR DESCRIPTION
Linux 4.11 added `statx`, which it seems libc now uses in preference to some of
the older stat calls.

Reported-by: Adrian Bunk <bunk@debian.org>
Debian: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1004035