### PR TITLE
Remove unnecessary constraints

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -3,12 +3,12 @@ Section: devel
 Priority: optional
 Maintainer: Matthew Fernandez <matthew.fernandez@gmail.com>
 Build-Depends: debhelper-compat (= 12),
- bison (>= 3.0),
- cmake (>= 3.1),
- flex (>= 2.5.35),
+ bison,
+ cmake,
+ flex,
  libfl-dev,
  libgmp-dev,
- python3 (>= 3.4),
+ python3,
  strace
 Standards-Version: 4.6.0.1
 Homepage: https://github.com/Smattr/rumur
@@ -19,7 +19,7 @@ Rules-Requires-Root: no
 Package: rumur
 Architecture: any
 Depends: ${shlibs:Depends}, ${misc:Depends}
-Suggests: python3 (>= 3.4)
+Suggests: python3
 Description: model checker for the Murphi language
  Rumur is a model checker for use in the formal verification of finite state
  machines specified in the Murphi modelling language. It is based on a previous


### PR DESCRIPTION

Remove unnecessary constraints.


This merge proposal was created automatically by the [Janitor bot](https://janitor.debian.net/scrub-obsolete).
For more information, including instructions on how to disable
these merge proposals, see https://janitor.debian.net/scrub-obsolete.

You can follow up to this merge proposal as you normally would.

The bot will automatically update the merge proposal to resolve merge conflicts
or close the merge proposal when all changes are applied through other means
(e.g. cherry-picks). Updates may take several hours to propagate.

Build and test logs for this branch can be found at
https://janitor.debian.net/scrub-obsolete/pkg/rumur/2e6e28ec-8b7e-45f3-8f85-dc442b110408.



## Debdiff

These changes affect the binary packages:


[The following lists of changes regard files as different if they have
different names, permissions or owners.]
### Files in second set of .debs but not in first
    -rw-r--r--  root/root   /usr/lib/debug/.build-id/52/0943a4a0117f2e603b5fffa4fce545d36f5c49.debug
    -rw-r--r--  root/root   /usr/lib/debug/.build-id/53/96d5e58a41f7e6bb70539a540fd87777c09eba.debug
    -rw-r--r--  root/root   /usr/lib/debug/.build-id/6e/b135fb26e0df9e2b935f9474db8ac3b4614de9.debug
    -rw-r--r--  root/root   /usr/lib/debug/.build-id/86/48169a2e785a62360d9637e60ba650642dd95b.debug
    -rw-r--r--  root/root   /usr/lib/debug/.build-id/90/7c481bb4282620ce83e9692c79b708ab3729d5.debug
### Files in first set of .debs but not in second
    -rw-r--r--  root/root   /usr/lib/debug/.build-id/3c/f2e2167d95e728d61adbcf59694de408f51844.debug
    -rw-r--r--  root/root   /usr/lib/debug/.build-id/68/998c20b23b87d7a074c4667cdc956268c3de3b.debug
    -rw-r--r--  root/root   /usr/lib/debug/.build-id/6a/2164f090abf46b04b823b6a0bc8c4cbd037670.debug
    -rw-r--r--  root/root   /usr/lib/debug/.build-id/7f/9bfe3046affb44c07645690ef4b25c8d11509b.debug
    -rw-r--r--  root/root   /usr/lib/debug/.build-id/f2/5a674f2f51ce1b76ff1e466d5010b36b9a16ff.debug
### Control files of package rumur: lines which differ (wdiff format)
* Suggests: python3 [-(>= 3.4)-]
### Control files of package rumur-dbgsym: lines which differ (wdiff format)
* Build-Ids: [-3cf2e2167d95e728d61adbcf59694de408f51844 68998c20b23b87d7a074c4667cdc956268c3de3b 6a2164f090abf46b04b823b6a0bc8c4cbd037670 7f9bfe3046affb44c07645690ef4b25c8d11509b f25a674f2f51ce1b76ff1e466d5010b36b9a16ff-] {+520943a4a0117f2e603b5fffa4fce545d36f5c49 5396d5e58a41f7e6bb70539a540fd87777c09eba 6eb135fb26e0df9e2b935f9474db8ac3b4614de9 8648169a2e785a62360d9637e60ba650642dd95b 907c481bb4282620ce83e9692c79b708ab3729d5+}


You can also view the [diffoscope diff](https://janitor.debian.net/api/run/2e6e28ec-8b7e-45f3-8f85-dc442b110408/diffoscope?filter_boring=1) ([unfiltered](https://janitor.debian.net/api/run/2e6e28ec-8b7e-45f3-8f85-dc442b110408/diffoscope)).
