### PR TITLE
CI: upgrade FreeBSD 13.0 to 13.1

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -32,13 +32,6 @@ task:
         image_family: freebsd-12-2-snap
       install_script: pkg upgrade -y && pkg install -y bash bison cmake gmp libxml2 z3
 
-    - name: Linux, GCC 4.9
-      container:
-        image: gcc:4.9
-      environment:
-        DEBIAN_FRONTEND: noninteractive
-        PATH: /opt/cmake-3.22.0-linux-x86_64/bin:${PATH}
-      install_script: apt-get update -y && apt-get install --no-install-recommends -y --force-yes bison flex libgmp-dev python3 && wget https://cmake.org/files/v3.22/cmake-3.22.0-linux-x86_64.tar.gz && mkdir -p /opt && tar xvf cmake-3.22.0-linux-x86_64.tar.gz --directory /opt
     - name: Linux, GCC 8.5
       container:
         image: gcc:8.5

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -17,13 +17,13 @@ task:
       environment:
         CMAKE_OPTIONS: -DBUILD_SHARED_LIBS=ON
       install_script: pkg upgrade -y && pkg install -y bash bison cmake gmp libxml2 z3
-    - name: FreeBSD 13.0
+    - name: FreeBSD 13.1
       freebsd_instance:
-        image_family: freebsd-13-0-snap
+        image_family: freebsd-13-1
       install_script: pkg upgrade -y && pkg install -y bash bison cmake gmp libxml2 z3
-    - name: FreeBSD 13.0, shared libraries
+    - name: FreeBSD 13.1, shared libraries
       freebsd_instance:
-        image_family: freebsd-13-0-snap
+        image_family: freebsd-13-1
       environment:
         CMAKE_OPTIONS: -DBUILD_SHARED_LIBS=ON
       install_script: pkg upgrade -y && pkg install -y bash bison cmake gmp libxml2 z3

--- a/librumur/src/parser.yy
+++ b/librumur/src/parser.yy
@@ -86,6 +86,11 @@
 
   #include <rumur/scanner.h>
 
+  /* squash warnings that Bison-generated code triggers under Clang ≥14 */
+  #ifdef __clang__
+  #pragma clang diagnostic push
+  #pragma clang diagnostic ignored "-Wunused-but-set-variable"
+  #endif
 }
 
   /* Tell Bison that the parser receives a reference to an instance of our


### PR DESCRIPTION
This also moves to the release images rather than the snaps. The release images seem somewhat more predictable and stable.