### PR TITLE
avoid linking libatomic if possible on ARM64

### DIFF
--- a/doc/internals-atomics.rst
+++ b/doc/internals-atomics.rst
@@ -68,9 +68,10 @@ Some relevant points to note from this table and from other sources:
 * Some of the C11 atomics expect to operate on ``atomic_`` types and are not
   directly usable on regular variables.
 * Double-word compare and exchange using either the __atomic built-ins or the
-  C11 atomics causes a call to libatomic to be emitted. This is functionally
-  correct but impairs our ability to use these in lock-free algorithms. See
-  https://gcc.gnu.org/bugzilla/show_bug.cgi?id=80878 for more information.
+  C11 atomics causes a call to libatomic to be emitted by GCC. This is
+  functionally correct but impairs our ability to use these in lock-free
+  algorithms. See https://gcc.gnu.org/bugzilla/show_bug.cgi?id=80878 and
+  https://gcc.gnu.org/pipermail/gcc-help/2017-June.txt for more information.
 * The C11 atomics are not available prior to GCC 4.9.
 
 With these constraints in mind, the checker that Rumur generates mostly uses

--- a/rumur/resources/header.c
+++ b/rumur/resources/header.c
@@ -2482,8 +2482,11 @@ static dword_t atomic_read(dword_t *p) {
    * i386: __atomic_load_n emits code calling a libatomic function that takes a
    *   lock, making this no longer lock free. Force a CMPXCHG8B by using the
    *   __sync built-in instead.
+   *
+   * XXX: the obvious (irrelevant) literal to use here is “0” but this triggers
+   * a GCC bug on ARM, https://gcc.gnu.org/bugzilla/show_bug.cgi?id=114310.
    */
-  return __sync_val_compare_and_swap(p, 0, 0);
+  return __sync_val_compare_and_swap(p, 1, 1);
 #endif
 
   return __atomic_load_n(p, __ATOMIC_SEQ_CST);

--- a/rumur/resources/header.c
+++ b/rumur/resources/header.c
@@ -91,10 +91,18 @@ enum {
  *      with atomic semantics and sometimes as regular memory operations. The
  *      C11 atomics cannot give us this and the __atomic built-ins are
  *      implemented by the major compilers.
- *   2. GCC __sync built-ins: used for 128-bit atomic accesses on x86-64. It
- *      seems the __atomic built-ins do not result in a CMPXCHG instruction, but
- *      rather in a less efficient library call. See
- *      https://gcc.gnu.org/bugzilla/show_bug.cgi?id=80878.
+ *   2. GCC __sync built-ins: used for 128-bit atomic accesses on x86-64 and
+ *      ARM64.
+ *        2a. On x86-64, it seems the __atomic built-ins do not result in a
+ *            CMPXCHG instruction, but rather in a less efficient library call.
+ *            See https://gcc.gnu.org/bugzilla/show_bug.cgi?id=80878.
+ *        2b. On ARM64, it seems the __atomic built-ins do not result in a CASP
+ *            instruction (available in ≥armv8.1-a, “Large System Extensions”),
+ *            but rather in a less efficient library call. See
+ *            https://gcc.gnu.org/pipermail/gcc-help/2017-June.txt. It seems
+ *            undocumented, but the __sync built-ins emit a CASP with
+ *            ≥-march=armv8.1a. This only affects GCC, not Clang which will emit
+ *            a CASP for both __atomic and __sync built-ins.
  *
  * Though this is intended to be a C11 program, we avoid the C11 atomics to be
  * compatible with GCC <4.9.
@@ -2475,13 +2483,17 @@ static dword_t atomic_read(dword_t *p) {
     return *p;
   }
 
-#if defined(__x86_64__) || defined(__i386__)
+#if defined(__x86_64__) || defined(__i386__) || \
+    (defined(__aarch64__) && defined(__GNUC__) && !defined(__clang__))
   /* x86-64: MOV is not guaranteed to be atomic on 128-bit naturally aligned
    *   memory. The way to work around this is apparently the following
    *   degenerate CMPXCHG16B.
    * i386: __atomic_load_n emits code calling a libatomic function that takes a
    *   lock, making this no longer lock free. Force a CMPXCHG8B by using the
    *   __sync built-in instead.
+   * ARM64: __atomic_load_n emits code calling a libatomic function that takes a
+   *   lock, making this no longer lock free. Force a CASP by using the __sync
+   *   built-in instead.
    *
    * XXX: the obvious (irrelevant) literal to use here is “0” but this triggers
    * a GCC bug on ARM, https://gcc.gnu.org/bugzilla/show_bug.cgi?id=114310.
@@ -2499,9 +2511,10 @@ static void atomic_write(dword_t *p, dword_t v) {
     return;
   }
 
-#if defined(__x86_64__) || defined(__i386__)
+#if defined(__x86_64__) || defined(__i386__) || \
+    (defined(__aarch64__) && defined(__GNUC__) && !defined(__clang__))
   /* As explained above, we need some extra gymnastics to avoid a call to
-   * libatomic on x86-64 and i386.
+   * libatomic on x86-64, i386, and ARM64.
    */
   dword_t expected;
   dword_t old = 0;
@@ -2525,9 +2538,11 @@ static bool atomic_cas(dword_t *p, dword_t expected, dword_t new) {
     return false;
   }
 
-#if defined(__x86_64__) || defined(__i386__)
+#if defined(__x86_64__) || defined(__i386__) || \
+    (defined(__aarch64__) && defined(__GNUC__) && !defined(__clang__))
   /* Make GCC >= 7.1 emit cmpxchg on x86-64 and i386. See
    * https://gcc.gnu.org/bugzilla/show_bug.cgi?id=80878.
+   * Make GCC emit a CASP on ARM64 (undocumented?).
    */
   return __sync_bool_compare_and_swap(p, expected, new);
 #endif
@@ -2546,9 +2561,11 @@ static dword_t atomic_cas_val(dword_t *p, dword_t expected, dword_t new) {
     return old;
   }
 
-#if defined(__x86_64__) || defined(__i386__)
+#if defined(__x86_64__) || defined(__i386__) || \
+    (defined(__aarch64__) && defined(__GNUC__) && !defined(__clang__))
   /* Make GCC >= 7.1 emit cmpxchg on x86-64 and i386. See
    * https://gcc.gnu.org/bugzilla/show_bug.cgi?id=80878.
+   * Make GCC emit a CASP on ARM64 (undocumented?).
    */
   return __sync_val_compare_and_swap(p, expected, new);
 #endif

--- a/rumur/src/main.cc
+++ b/rumur/src/main.cc
@@ -721,6 +721,7 @@ int main(int argc, char **argv) {
                           "c",
                           "-o",
                           "/dev/null",
+                          "-march=native",
                           "-Werror=format",
                           "-Werror=sign-compare",
                           "-Werror=type-limits",

--- a/rumur/src/rumur-run
+++ b/rumur/src/rumur-run
@@ -107,13 +107,17 @@ static dword_t atomic_read(dword_t *p) {
     return *p;
   }
 
-#if defined(__x86_64__) || defined(__i386__)
+#if defined(__x86_64__) || defined(__i386__) || \
+    (defined(__aarch64__) && defined(__GNUC__) && !defined(__clang__))
   /* x86-64: MOV is not guaranteed to be atomic on 128-bit naturally aligned
    *   memory. The way to work around this is apparently the following
    *   degenerate CMPXCHG16B.
    * i386: __atomic_load_n emits code calling a libatomic function that takes a
    *   lock, making this no longer lock free. Force a CMPXCHG8B by using the
    *   __sync built-in instead.
+   * ARM64: __atomic_load_n emits code calling a libatomic function that takes a
+   *   lock, making this no longer lock free. Force a CASP by using the __sync
+   *   built-in instead.
    *
    * XXX: the obvious (irrelevant) literal to use here is “0” but this triggers
    * a GCC bug on ARM, https://gcc.gnu.org/bugzilla/show_bug.cgi?id=114310.
@@ -131,9 +135,10 @@ static void atomic_write(dword_t *p, dword_t v) {
     return;
   }
 
-#if defined(__x86_64__) || defined(__i386__)
+#if defined(__x86_64__) || defined(__i386__) || \
+    (defined(__aarch64__) && defined(__GNUC__) && !defined(__clang__))
   /* As explained above, we need some extra gymnastics to avoid a call to
-   * libatomic on x86-64 and i386.
+   * libatomic on x86-64, i386, and ARM64.
    */
   dword_t expected;
   dword_t old = 0;
@@ -157,9 +162,11 @@ static bool atomic_cas(dword_t *p, dword_t expected, dword_t new) {
     return false;
   }
 
-#if defined(__x86_64__) || defined(__i386__)
+#if defined(__x86_64__) || defined(__i386__) || \
+    (defined(__aarch64__) && defined(__GNUC__) && !defined(__clang__))
   /* Make GCC >= 7.1 emit cmpxchg on x86-64 and i386. See
    * https://gcc.gnu.org/bugzilla/show_bug.cgi?id=80878.
+   * Make GCC emit a CASP on ARM64 (undocumented?).
    */
   return __sync_bool_compare_and_swap(p, expected, new);
 #endif
@@ -178,9 +185,11 @@ static dword_t atomic_cas_val(dword_t *p, dword_t expected, dword_t new) {
     return old;
   }
 
-#if defined(__x86_64__) || defined(__i386__)
+#if defined(__x86_64__) || defined(__i386__) || \
+    (defined(__aarch64__) && defined(__GNUC__) && !defined(__clang__))
   /* Make GCC >= 7.1 emit cmpxchg on x86-64 and i386. See
    * https://gcc.gnu.org/bugzilla/show_bug.cgi?id=80878.
+   * Make GCC emit a CASP on ARM64 (undocumented?).
    */
   return __sync_val_compare_and_swap(p, expected, new);
 #endif

--- a/rumur/src/rumur-run
+++ b/rumur/src/rumur-run
@@ -114,8 +114,11 @@ static dword_t atomic_read(dword_t *p) {
    * i386: __atomic_load_n emits code calling a libatomic function that takes a
    *   lock, making this no longer lock free. Force a CMPXCHG8B by using the
    *   __sync built-in instead.
+   *
+   * XXX: the obvious (irrelevant) literal to use here is “0” but this triggers
+   * a GCC bug on ARM, https://gcc.gnu.org/bugzilla/show_bug.cgi?id=114310.
    */
-  return __sync_val_compare_and_swap(p, 0, 0);
+  return __sync_val_compare_and_swap(p, 1, 1);
 #endif
 
   return __atomic_load_n(p, __ATOMIC_SEQ_CST);

--- a/rumur/src/rumur-run
+++ b/rumur/src/rumur-run
@@ -206,6 +206,8 @@ int main(void) {
 
   # compile it
   args = [CC, "-x", "c", "-std=c11", "-", "-o", os.devnull]
+  if supports("-march=native"):
+    args.append("-march=native")
   if supports("-mcx16"):
     args.append("-mcx16")
   p = sp.Popen(args, stderr=sp.DEVNULL, stdin=sp.PIPE)

--- a/tests/config/C_FLAGS
+++ b/tests/config/C_FLAGS
@@ -16,6 +16,16 @@ if [ $? -eq 0 ]; then
   printf ', "-Werror=enum-conversion"'
 fi
 
+# test if the C compiler supports -march=native
+${CC:-cc} -x c -std=c11 -march=native -o /dev/null - &>/dev/null <<EOT
+int main(void) {
+  return 0;
+}
+EOT
+if [ $? -eq 0 ]; then
+  printf ', "-march=native"'
+fi
+
 # test if the C compiler supports -mcx16
 ${CC:-cc} -x c -std=c11 -mcx16 -o /dev/null - &>/dev/null <<EOT
 int main(void) {

--- a/tests/config/HAS_MARCH_NATIVE
+++ b/tests/config/HAS_MARCH_NATIVE
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+# does the compiler support -march=native?
+
+
+# try to compile something using -march=native
+${CC:-cc} -x c -std=c11 -march=native -o /dev/null - &>/dev/null <<EOT
+int main(void) {
+  return 0;
+}
+EOT
+
+# see if the compiler errored
+if [ $? -eq 0 ]; then
+  printf 'True\n'
+else
+  printf 'False\n'
+fi

--- a/tests/config/NEEDS_LIBATOMIC
+++ b/tests/config/NEEDS_LIBATOMIC
@@ -45,8 +45,11 @@ static dword_t atomic_read(dword_t *p) {
    * i386: __atomic_load_n emits code calling a libatomic function that takes a
    *   lock, making this no longer lock free. Force a CMPXCHG8B by using the
    *   __sync built-in instead.
+   *
+   * XXX: the obvious (irrelevant) literal to use here is “0” but this triggers
+   * a GCC bug on ARM, https://gcc.gnu.org/bugzilla/show_bug.cgi?id=114310.
    */
-  return __sync_val_compare_and_swap(p, 0, 0);
+  return __sync_val_compare_and_swap(p, 1, 1);
 #endif
 
   return __atomic_load_n(p, __ATOMIC_SEQ_CST);

--- a/tests/config/NEEDS_LIBATOMIC
+++ b/tests/config/NEEDS_LIBATOMIC
@@ -3,6 +3,18 @@
 # does the toolchain need -latomic to support dword CAS?
 
 
+# repeat the HAS_MARCH_NATIVE logic
+${CC:-cc} -x c -std=c11 -march=native -o /dev/null - &>/dev/null <<EOT
+int main(void) {
+  return 0;
+}
+EOT
+if [ $? -eq 0 ]; then
+  MARCH=-march=native
+else
+  MARCH=
+fi
+
 # repeat the HAS_MCX16 logic
 ${CC:-cc} -x c -std=c11 -mcx16 -o /dev/null - &>/dev/null <<EOT
 int main(void) {
@@ -16,7 +28,7 @@ else
 fi
 
 # compile a program that operates on a double-word
-${CC:-cc} -x c -std=c11 ${MCX16} -o /dev/null - &>/dev/null <<EOT
+${CC:-cc} -x c -std=c11 ${MARCH} ${MCX16} -o /dev/null - &>/dev/null <<EOT
 #include <stdbool.h>
 #include <stdint.h>
 

--- a/tests/config/NEEDS_LIBATOMIC
+++ b/tests/config/NEEDS_LIBATOMIC
@@ -50,13 +50,17 @@ static dword_t atomic_read(dword_t *p) {
     return *p;
   }
 
-#if defined(__x86_64__) || defined(__i386__)
+#if defined(__x86_64__) || defined(__i386__) || \
+    (defined(__aarch64__) && defined(__GNUC__) && !defined(__clang__))
   /* x86-64: MOV is not guaranteed to be atomic on 128-bit naturally aligned
    *   memory. The way to work around this is apparently the following
    *   degenerate CMPXCHG16B.
    * i386: __atomic_load_n emits code calling a libatomic function that takes a
    *   lock, making this no longer lock free. Force a CMPXCHG8B by using the
    *   __sync built-in instead.
+   * ARM64: __atomic_load_n emits code calling a libatomic function that takes a
+   *   lock, making this no longer lock free. Force a CASP by using the __sync
+   *   built-in instead.
    *
    * XXX: the obvious (irrelevant) literal to use here is “0” but this triggers
    * a GCC bug on ARM, https://gcc.gnu.org/bugzilla/show_bug.cgi?id=114310.
@@ -74,9 +78,10 @@ static void atomic_write(dword_t *p, dword_t v) {
     return;
   }
 
-#if defined(__x86_64__) || defined(__i386__)
+#if defined(__x86_64__) || defined(__i386__) || \
+    (defined(__aarch64__) && defined(__GNUC__) && !defined(__clang__))
   /* As explained above, we need some extra gymnastics to avoid a call to
-   * libatomic on x86-64 and i386.
+   * libatomic on x86-64, i386, and ARM64.
    */
   dword_t expected;
   dword_t old = 0;
@@ -100,9 +105,11 @@ static bool atomic_cas(dword_t *p, dword_t expected, dword_t new) {
     return false;
   }
 
-#if defined(__x86_64__) || defined(__i386__)
+#if defined(__x86_64__) || defined(__i386__) || \
+    (defined(__aarch64__) && defined(__GNUC__) && !defined(__clang__))
   /* Make GCC >= 7.1 emit cmpxchg on x86-64 and i386. See
    * https://gcc.gnu.org/bugzilla/show_bug.cgi?id=80878.
+   * Make GCC emit a CASP on ARM64 (undocumented?).
    */
   return __sync_bool_compare_and_swap(p, expected, new);
 #endif
@@ -121,9 +128,11 @@ static dword_t atomic_cas_val(dword_t *p, dword_t expected, dword_t new) {
     return old;
   }
 
-#if defined(__x86_64__) || defined(__i386__)
+#if defined(__x86_64__) || defined(__i386__) || \
+    (defined(__aarch64__) && defined(__GNUC__) && !defined(__clang__))
   /* Make GCC >= 7.1 emit cmpxchg on x86-64 and i386. See
    * https://gcc.gnu.org/bugzilla/show_bug.cgi?id=80878.
+   * Make GCC emit a CASP on ARM64 (undocumented?).
    */
   return __sync_val_compare_and_swap(p, expected, new);
 #endif

--- a/tests/lock-freedom-aarch64.py
+++ b/tests/lock-freedom-aarch64.py
@@ -1,0 +1,23 @@
+#!/usr/bin/env python3
+
+"""
+Version of lock-freedom.py for ARM64, which needs -march=native
+"""
+
+import os
+import subprocess
+import sys
+
+# this test is only relevant on ≥ARMv8.1a
+CC = os.environ.get("CC", "cc")
+argv = [CC, "-std=c11", "-march=armv8.1-a", "-x", "c", "-", "-o", os.devnull]
+p = subprocess.Popen(argv, stdin=subprocess.PIPE, stderr=subprocess.DEVNULL,
+  universal_newlines=True)
+p.communicate("int main(void) { return 0; }")
+if p.returncode != 0:
+  print("only relevant for ≥ARMv8.1a machines")
+  sys.exit(125)
+
+# call the generic lock-freedom.py with some customisation
+lock_freedom_py = os.path.join(os.path.dirname(__file__), "lock-freedom.py")
+sys.exit(subprocess.call(["python3", lock_freedom_py, "-march=armv8.1-a"]))

--- a/tests/lock-freedom.py
+++ b/tests/lock-freedom.py
@@ -37,7 +37,8 @@ if p.returncode != 0:
 
 # check for calls to libatomic functions
 if "__atomic_" in model_s.decode("utf-8", "replace"):
-  print("libatomic calls in generated code were not optimised out")
+  print("libatomic calls in generated code were not optimised out:\n{}".format(
+    model_s.decode("utf-8", "replace")))
   sys.exit(-1)
 
 # pass

--- a/tests/strace-sandbox.sh
+++ b/tests/strace-sandbox.sh
@@ -48,6 +48,13 @@ EOT
 # generate a sandboxed checker
 rumur --sandbox on --output model.c model.m
 
+# check if the compiler supports -march=native
+if [ "${HAS_MARCH_NATIVE}" = "True" ]; then
+  MARCH=-march=native
+else
+  MARCH=
+fi
+
 # check if the compiler supports -mcx16
 if [ "${HAS_MCX16}" = "True" ]; then
   MCX16=-mcx16
@@ -63,7 +70,7 @@ else
 fi
 
 # compile the sandboxed checker
-${CC:-cc} -std=c11 ${MCX16} model.c -o model.exe ${LIBATOMIC} -lpthread
+${CC:-cc} -std=c11 ${MARCH} ${MCX16} model.c -o model.exe ${LIBATOMIC} -lpthread
 
 # run the model under strace
 strace ./model.exe
@@ -77,7 +84,7 @@ if [ $RET -eq 0 ]; then
   rumur --sandbox on --debug --output model.c model.m
 
   # compile the sandboxed checker
-  ${CC:-cc} -std=c11 ${MCX16} model.c -o model.exe ${LIBATOMIC} -lpthread
+  ${CC:-cc} -std=c11 ${MARCH} ${MCX16} model.c -o model.exe ${LIBATOMIC} -lpthread
 
   # run the model under strace
   strace ./model.exe


### PR DESCRIPTION
Double-word atomics are used to implement lock-free reference-counted pointers.¹
Compiler built-ins (the GCC __sync and __atomic built-ins) are used to access
this functionality. It is up to the compiler how to lower these built-ins, and
it chooses between emitting inline instructions or calling into the libatomic
runtime support library.² The implementations in libatomic are typically not
lock-free – they work by using per-variable-instance mutexes – which negates the
performance benefits of the lock-free algorithm we are trying to implement. In
tight code like our scenario, the function call overhead into libatomic is also
a noticeable factor.

It was observed that on ARM64 GCC lowers these __atomic built-ins into libatomic
calls. ARM64 has Load-Linked/Store-Conditional (LL/SC) instructions that can be
used to implement these inline, but GCC has traditionally avoided using these to
back the atomics.³ While compiler developers were debating the utility of these
instructions, ARM introduced “Large System Extensions,” adding a new CASP family
of instructions that more efficiently implements compare-and-swap.

So our aim is to use the CASP instructions where possible. We have the following
matrix:

```
  ┌──────┬───────────────────────┬───────────────────────┐
  │      │       Clang           │         GCC           │
  ├──────┼───────────────────────┼───────────────────────┤
  │ load │     __atomic          │       __sync          │
  │      │ <armv8.1-a: LL/SC     │ <armv8.1-a: libatomic │
  │      │ ≥armv8.1-a: CASP      │ ≥armv8.1-a: CASP      │
  ├──────┼───────────────────────┼───────────────────────┤
  │ store│     __atomic          │       __sync          │
  │      │ <armv8.1-a: LL/SC     │ <armv8.1-a: libatomic │
  │      │ ≥armv8.1-a: CASP      │ ≥armv8.1-a: CASP      │
  ├──────┼───────────────────────┼───────────────────────┤
  │ CAS  │     __atomic          │       __sync          │
  │      │ <armv8.1-a: libatomic │ <armv8.1-a: libatomic │
  │      │ ≥armv8.1-a: CASP      │ ≥armv8.1-a: CASP      │
  └──────┴───────────────────────┴───────────────────────┘
```

This seems to result in a near-optimal situation on ≥armv8.1-a. For <armv8.1-a,
the only way to avoid linking against libatomic seems to be resorting to inline
assembly which is not worthwhile.

Reported-by: e69d5a347277e5e7cb23518d93266bdac89a4bad

¹ Specifically “Hazard Pointers” as described in Maged Michael’s “Hazard
  Pointers: Safe Memory Reclamation for Lock-Free Objects” in TPDS 15(8) 2004.
² GCC 10.1 introduced a third option that does a runtime check, similar to GNU
  indirect functions (IFUNCs),
  https://community.arm.com/arm-community-blogs/b/tools-software-ides-blog/posts/making-the-most-of-the-arm-architecture-in-gcc-10.
  However, this is not relevant to us.
³ See https://gcc.gnu.org/pipermail/gcc-help/2017-June.txt for a lengthy debate
  on this and https://gcc.gnu.org/bugzilla/show_bug.cgi?id=80878 for the
  underlying rationale for avoiding both LL/SC and cmpxchg for backing these
  atomics. As one participant in the first linked discussion accurately
  summarises, “I think what’s happened makes perfect sense at each step of the
  way but has led to an outcome which is crazy.”