### PR TITLE
murphi2murphi: fix: use original token when testing for comment begin

### DIFF
--- a/murphi2murphi/src/ToAscii.cc
+++ b/murphi2murphi/src/ToAscii.cc
@@ -47,9 +47,9 @@ void ToAscii::process(const Token &t) {
 
   case IDLE:
     next << s;
-    if (s == "-") {
+    if (t.character == "-") {
       state = IDLE_DASH;
-    } else if (s == "/") {
+    } else if (t.character == "/") {
       state = IDLE_SLASH;
     } else if (s == "\"") {
       state = IN_STRING;
@@ -58,9 +58,9 @@ void ToAscii::process(const Token &t) {
 
   case IDLE_DASH:
     next << s;
-    if (s == "-") {
+    if (t.character == "-") {
       state = IN_LINE_COMMENT;
-    } else if (s == "/") {
+    } else if (t.character == "/") {
       state = IDLE_SLASH;
     } else if (s == "\"") {
       state = IN_STRING;
@@ -71,11 +71,11 @@ void ToAscii::process(const Token &t) {
 
   case IDLE_SLASH:
     next << s;
-    if (s == "-") {
+    if (t.character == "-") {
       state = IDLE_DASH;
-    } else if (s == "/") {
+    } else if (t.character == "/") {
       // stay in IDLE_SLASH
-    } else if (s == "*") {
+    } else if (t.character == "*") {
       state = IN_MULTILINE_COMMENT;
     } else if (s == "\"") {
       state = IN_STRING;


### PR DESCRIPTION
a9de733aba646e1b0612269bbba6c8e21f485584,
5dac72950d59457aba636cb58487e54120338c7f,
10acb27984e0580e30e0d995cf89d2b50fba10bb, and
cc345ea2b6beebe63951549b9d6616f533dd1d2e introduced handling of some unicode characters that map to ASCII characters involved in starting a comment. These would incorrectly be considered as eligible aliases within comment tokens. E.g. `÷×` would be treated as validly starting a multi-line comment.

This problem seems somewhat latent in that most sequences that would be confused in this way are not valid Murphi substrings anyway. The only one I can come up with is:

```
  x := y −-- a comment
   --    ▲▲
   --    │└─ actual start of the comment
   --    └─ unicode subtraction character
   z; -- ◄── conclusion of the subtraction
```

This would be misinterpreted as the comment starting one character earlier. It is unclear whether this is an actual problem because the translation both before and after this change is identical; it is only the internal state of `murphi2murphi` that differs. Translation of something like this produces invalid Murphi source, but it is unclear what the user would want to happen here.