### PR TITLE
use close-on-exec to more simply clean up pipe file descriptors

### DIFF
--- a/murphi2c/src/main.cc
+++ b/murphi2c/src/main.cc
@@ -69,7 +69,7 @@ static void parse_args(int argc, char **argv) {
     case 'o': {
       auto o = std::make_shared<std::ofstream>(optarg);
       if (!o->is_open()) {
-        std::cerr << "failed to open " << optarg << "\n";
+        std::cerr << "failed to open " << optarg << '\n';
         exit(EXIT_FAILURE);
       }
       out = o;
@@ -86,7 +86,7 @@ static void parse_args(int argc, char **argv) {
       break;
 
     case 131: // --version
-      std::cout << "Murphi2C version " << rumur::get_version() << "\n";
+      std::cout << "Murphi2C version " << rumur::get_version() << '\n';
       exit(EXIT_SUCCESS);
 
     default:
@@ -99,7 +99,7 @@ static void parse_args(int argc, char **argv) {
     struct stat buf;
     if (stat(argv[optind], &buf) < 0) {
       std::cerr << "failed to open " << argv[optind] << ": " << strerror(errno)
-                << "\n";
+                << '\n';
       exit(EXIT_FAILURE);
     }
 
@@ -114,7 +114,7 @@ static void parse_args(int argc, char **argv) {
     auto i = std::make_shared<std::ifstream>(in_filename);
     auto j = std::make_shared<std::ifstream>(in_filename);
     if (!i->is_open() || !j->is_open()) {
-      std::cerr << "failed to open " << in_filename << "\n";
+      std::cerr << "failed to open " << in_filename << '\n';
       exit(EXIT_FAILURE);
     }
     in = dup_t(i, j);
@@ -148,7 +148,7 @@ int main(int argc, char **argv) {
   try {
     m = rumur::parse(*in.first);
   } catch (rumur::Error &e) {
-    std::cerr << e.loc << ":" << e.what() << "\n";
+    std::cerr << e.loc << ":" << e.what() << '\n';
     return EXIT_FAILURE;
   }
 
@@ -162,7 +162,7 @@ int main(int argc, char **argv) {
     resolve_symbols(*m);
     validate(*m);
   } catch (rumur::Error &e) {
-    std::cerr << e.loc << ":" << e.what() << "\n";
+    std::cerr << e.loc << ":" << e.what() << '\n';
     return EXIT_FAILURE;
   }
 

--- a/murphi2murphi/src/main.cc
+++ b/murphi2murphi/src/main.cc
@@ -111,7 +111,7 @@ static void parse_args(int argc, char **argv) {
     case 'o': { // --output
       auto o = std::make_shared<std::ofstream>(optarg);
       if (!o->is_open()) {
-        std::cerr << "failed to open " << optarg << "\n";
+        std::cerr << "failed to open " << optarg << '\n';
         exit(EXIT_FAILURE);
       }
       out = o;
@@ -131,7 +131,7 @@ static void parse_args(int argc, char **argv) {
       break;
 
     case 138: // --version
-      std::cout << "Murphi2Murphi version " << get_version() << "\n";
+      std::cout << "Murphi2Murphi version " << get_version() << '\n';
       exit(EXIT_SUCCESS);
 
     default:
@@ -144,7 +144,7 @@ static void parse_args(int argc, char **argv) {
     struct stat buf;
     if (stat(argv[optind], &buf) < 0) {
       std::cerr << "failed to open " << argv[optind] << ": " << strerror(errno)
-                << "\n";
+                << '\n';
       exit(EXIT_FAILURE);
     }
 
@@ -156,7 +156,7 @@ static void parse_args(int argc, char **argv) {
 
     auto i = std::make_shared<std::ifstream>(argv[optind]);
     if (!i->is_open()) {
-      std::cerr << "failed to open " << argv[optind] << "\n";
+      std::cerr << "failed to open " << argv[optind] << '\n';
       exit(EXIT_FAILURE);
     }
     in = i;
@@ -164,7 +164,7 @@ static void parse_args(int argc, char **argv) {
     // open the input again that we need for replay during XML output
     auto i2 = std::make_shared<std::ifstream>(argv[optind]);
     if (!i2->is_open()) {
-      std::cerr << "failed to open " << argv[optind] << "\n";
+      std::cerr << "failed to open " << argv[optind] << '\n';
       exit(EXIT_FAILURE);
     }
     in_replay = i2;
@@ -186,7 +186,7 @@ int main(int argc, char **argv) {
   try {
     m = parse(*in);
   } catch (Error &e) {
-    std::cerr << e.loc << ":" << e.what() << "\n";
+    std::cerr << e.loc << ":" << e.what() << '\n';
     return EXIT_FAILURE;
   }
 
@@ -200,7 +200,7 @@ int main(int argc, char **argv) {
     resolve_symbols(*m);
     validate(*m);
   } catch (Error &e) {
-    std::cerr << e.loc << ":" << e.what() << "\n";
+    std::cerr << e.loc << ":" << e.what() << '\n';
     return EXIT_FAILURE;
   }
 
@@ -239,7 +239,7 @@ int main(int argc, char **argv) {
     pipe.finalise();
 
   } catch (Error &e) {
-    std::cerr << e.loc << ":" << e.what() << "\n";
+    std::cerr << e.loc << ":" << e.what() << '\n';
     return EXIT_FAILURE;
   }
 

--- a/murphi2smv/src/main.cc
+++ b/murphi2smv/src/main.cc
@@ -56,7 +56,7 @@ static void parse_args(int argc, char **argv) {
 
     case 'n': // --numeric-type
       if (optarg != std::string{"integer"} && optarg != std::string{"word"}) {
-        std::cerr << "invalid argument to --numeric-type " << optarg << "\n";
+        std::cerr << "invalid argument to --numeric-type " << optarg << '\n';
         exit(EXIT_FAILURE);
       }
       numeric_type = optarg;
@@ -67,7 +67,7 @@ static void parse_args(int argc, char **argv) {
       break;
 
     case 128: // --version
-      std::cout << "Murphi2SMV version " << rumur::get_version() << "\n";
+      std::cout << "Murphi2SMV version " << rumur::get_version() << '\n';
       exit(EXIT_SUCCESS);
 
     default:
@@ -80,7 +80,7 @@ static void parse_args(int argc, char **argv) {
     struct stat buf;
     if (stat(argv[optind], &buf) < 0) {
       std::cerr << "failed to open " << argv[optind] << ": " << strerror(errno)
-                << "\n";
+                << '\n';
       exit(EXIT_FAILURE);
     }
 
@@ -95,7 +95,7 @@ static void parse_args(int argc, char **argv) {
     auto i = std::make_shared<std::ifstream>(in_filename);
     auto j = std::make_shared<std::ifstream>(in_filename);
     if (!i->is_open() || !j->is_open()) {
-      std::cerr << "failed to open " << in_filename << "\n";
+      std::cerr << "failed to open " << in_filename << '\n';
       exit(EXIT_FAILURE);
     }
     in = dup_t{i, j};
@@ -133,7 +133,7 @@ int main(int argc, char **argv) {
   try {
     m = rumur::parse(*in.first);
   } catch (rumur::Error &e) {
-    std::cerr << e.loc << ":" << e.what() << "\n";
+    std::cerr << e.loc << ":" << e.what() << '\n';
     return EXIT_FAILURE;
   }
 
@@ -147,7 +147,7 @@ int main(int argc, char **argv) {
     resolve_symbols(*m);
     validate(*m);
   } catch (rumur::Error &e) {
-    std::cerr << e.loc << ":" << e.what() << "\n";
+    std::cerr << e.loc << ":" << e.what() << '\n';
     return EXIT_FAILURE;
   }
 
@@ -163,7 +163,7 @@ int main(int argc, char **argv) {
   if (out_filename != "-") {
     auto o = std::make_shared<std::ofstream>(out_filename);
     if (!o->is_open()) {
-      std::cerr << "failed to open " << out_filename << "\n";
+      std::cerr << "failed to open " << out_filename << '\n';
       exit(EXIT_FAILURE);
     }
     out = o;

--- a/murphi2uclid/src/main.cc
+++ b/murphi2uclid/src/main.cc
@@ -87,7 +87,7 @@ static void parse_args(int argc, char **argv) {
 
     case 'n': // --numeric-type
       if (!is_valid_numeric_type(optarg)) {
-        std::cerr << "invalid argument to --numeric-type " << optarg << "\n";
+        std::cerr << "invalid argument to --numeric-type " << optarg << '\n';
         exit(EXIT_FAILURE);
       }
       numeric_type = optarg;
@@ -106,7 +106,7 @@ static void parse_args(int argc, char **argv) {
       break;
 
     case 128: // --version
-      std::cout << "Murphi2Uclid version " << rumur::get_version() << "\n";
+      std::cout << "Murphi2Uclid version " << rumur::get_version() << '\n';
       exit(EXIT_SUCCESS);
 
     default:
@@ -119,7 +119,7 @@ static void parse_args(int argc, char **argv) {
     struct stat buf;
     if (stat(argv[optind], &buf) < 0) {
       std::cerr << "failed to open " << argv[optind] << ": " << strerror(errno)
-                << "\n";
+                << '\n';
       exit(EXIT_FAILURE);
     }
 
@@ -134,7 +134,7 @@ static void parse_args(int argc, char **argv) {
     auto i = std::make_shared<std::ifstream>(in_filename);
     auto j = std::make_shared<std::ifstream>(in_filename);
     if (!i->is_open() || !j->is_open()) {
-      std::cerr << "failed to open " << in_filename << "\n";
+      std::cerr << "failed to open " << in_filename << '\n';
       exit(EXIT_FAILURE);
     }
     in = dup_t(i, j);
@@ -172,7 +172,7 @@ int main(int argc, char **argv) {
   try {
     m = rumur::parse(*in.first);
   } catch (rumur::Error &e) {
-    std::cerr << e.loc << ":" << e.what() << "\n";
+    std::cerr << e.loc << ":" << e.what() << '\n';
     return EXIT_FAILURE;
   }
 
@@ -186,7 +186,7 @@ int main(int argc, char **argv) {
     resolve_symbols(*m);
     validate(*m);
   } catch (rumur::Error &e) {
-    std::cerr << e.loc << ":" << e.what() << "\n";
+    std::cerr << e.loc << ":" << e.what() << '\n';
     return EXIT_FAILURE;
   }
 
@@ -197,7 +197,7 @@ int main(int argc, char **argv) {
   try {
     check(*m);
   } catch (rumur::Error &e) {
-    std::cerr << e.loc << ":" << e.what() << "\n";
+    std::cerr << e.loc << ":" << e.what() << '\n';
     return EXIT_FAILURE;
   }
 
@@ -212,7 +212,7 @@ int main(int argc, char **argv) {
   if (out_filename != "-") {
     auto o = std::make_shared<std::ofstream>(out_filename);
     if (!o->is_open()) {
-      std::cerr << "failed to open " << out_filename << "\n";
+      std::cerr << "failed to open " << out_filename << '\n';
       exit(EXIT_FAILURE);
     }
     out = o;

--- a/murphi2xml/src/main.cc
+++ b/murphi2xml/src/main.cc
@@ -56,7 +56,7 @@ static void parse_args(int argc, char **argv) {
     case 'o': {
       auto o = std::make_shared<std::ofstream>(optarg);
       if (!o->is_open()) {
-        std::cerr << "failed to open " << optarg << "\n";
+        std::cerr << "failed to open " << optarg << '\n';
         exit(EXIT_FAILURE);
       }
       out = o;
@@ -64,7 +64,7 @@ static void parse_args(int argc, char **argv) {
     }
 
     case 128: // --version
-      std::cout << "Rumur version " << rumur::get_version() << "\n";
+      std::cout << "Rumur version " << rumur::get_version() << '\n';
       exit(EXIT_SUCCESS);
 
     default:
@@ -77,7 +77,7 @@ static void parse_args(int argc, char **argv) {
     struct stat buf;
     if (stat(argv[optind], &buf) < 0) {
       std::cerr << "failed to open " << argv[optind] << ": " << strerror(errno)
-                << "\n";
+                << '\n';
       exit(EXIT_FAILURE);
     }
 
@@ -91,7 +91,7 @@ static void parse_args(int argc, char **argv) {
 
     auto i = std::make_shared<std::ifstream>(in_filename);
     if (!i->is_open()) {
-      std::cerr << "failed to open " << in_filename << "\n";
+      std::cerr << "failed to open " << in_filename << '\n';
       exit(EXIT_FAILURE);
     }
     in = i;
@@ -99,7 +99,7 @@ static void parse_args(int argc, char **argv) {
     // open the input again that we need for replay during XML output
     auto i2 = std::make_shared<std::ifstream>(in_filename);
     if (!i2->is_open()) {
-      std::cerr << "failed to open " << in_filename << "\n";
+      std::cerr << "failed to open " << in_filename << '\n';
       exit(EXIT_FAILURE);
     }
     in_replay = i2;
@@ -121,7 +121,7 @@ int main(int argc, char **argv) {
   try {
     m = rumur::parse(*in);
   } catch (rumur::Error &e) {
-    std::cerr << e.loc << ":" << e.what() << "\n";
+    std::cerr << e.loc << ":" << e.what() << '\n';
     return EXIT_FAILURE;
   }
 
@@ -134,7 +134,7 @@ int main(int argc, char **argv) {
     resolve_symbols(*m);
     validate(*m);
   } catch (rumur::Error &e) {
-    std::cerr << e.loc << ":" << e.what() << "\n";
+    std::cerr << e.loc << ":" << e.what() << '\n';
     return EXIT_FAILURE;
   }
 

--- a/rumur/src/process.cc
+++ b/rumur/src/process.cc
@@ -1,5 +1,6 @@
 #include "process.h"
 #include "environ.h"
+#include <algorithm>
 #include <cassert>
 #include <cstddef>
 #include <cstdio>
@@ -80,8 +81,6 @@ fail:
   }
   return -1;
 }
-
-static int max(int a, int b) { return a > b ? a : b; }
 
 int run(const std::vector<std::string> &args, const std::string &input,
         std::string &output) {
@@ -168,14 +167,14 @@ int run(const std::vector<std::string> &args, const std::string &input,
     FD_ZERO(&readfds);
     FD_SET(out[READ_FD], &readfds);
     FD_SET(sigchld_pipe[READ_FD], &readfds);
-    nfds = max(out[READ_FD], sigchld_pipe[READ_FD]);
+    nfds = std::max(out[READ_FD], sigchld_pipe[READ_FD]);
 
     // create a set of only the in pipe (if still open) to monitor for writing
     fd_set writefds;
     FD_ZERO(&writefds);
     if (in[WRITE_FD] != -1) {
       FD_SET(in[WRITE_FD], &writefds);
-      nfds = max(nfds, in[WRITE_FD]);
+      nfds = std::max(nfds, in[WRITE_FD]);
     }
 
     // wait for an event

--- a/rumur/src/process.cc
+++ b/rumur/src/process.cc
@@ -64,7 +64,7 @@ static int init() {
 
   // register our redirecting signal handler
   if (signal(SIGCHLD, handler) == SIG_ERR) {
-    *debug << "failed to set SIGCHLD handler: " << strerror(errno) << "\n";
+    *debug << "failed to set SIGCHLD handler: " << strerror(errno) << '\n';
     goto fail;
   }
 
@@ -106,20 +106,20 @@ int run(const std::vector<std::string> &args, const std::string &input,
 
   err = posix_spawn_file_actions_init(&fa);
   if (err != 0) {
-    *debug << "failed file_actions_init: " << strerror(err) << "\n";
+    *debug << "failed file_actions_init: " << strerror(err) << '\n';
     return -1;
   }
 
   // create some pipes we'll use to communicate with the child
   if (pipe(in) < 0 || pipe(out) < 0) {
-    *debug << "failed pipe: " << strerror(errno) << "\n";
+    *debug << "failed pipe: " << strerror(errno) << '\n';
     goto done;
   }
 
   // set the ends the parent (us) will use as non-blocking
   if (fcntl(in[WRITE_FD], F_SETFL, fcntl(in[WRITE_FD], F_GETFL) | O_NONBLOCK) == -1 ||
       fcntl(out[READ_FD], F_SETFL, fcntl(out[READ_FD], F_GETFL) | O_NONBLOCK) == -1) {
-    *debug << "failed to set O_NONBLOCK: " << strerror(errno) << "\n";
+    *debug << "failed to set O_NONBLOCK: " << strerror(errno) << '\n';
     goto done;
   }
 
@@ -139,7 +139,7 @@ int run(const std::vector<std::string> &args, const std::string &input,
   if (err == 0)
     err = posix_spawn_file_actions_adddup2(&fa, out[WRITE_FD], STDERR_FILENO);
   if (err != 0) {
-    *debug << "failed file_actions_adddup2: " << strerror(err) << "\n";
+    *debug << "failed file_actions_adddup2: " << strerror(err) << '\n';
     goto done;
   }
 
@@ -147,7 +147,7 @@ int run(const std::vector<std::string> &args, const std::string &input,
   pid_t pid;
   err = posix_spawnp(&pid, argv[0], &fa, nullptr, argv.data(), get_environ());
   if (err != 0) {
-    *debug << "failed posix_spawnp: " << strerror(err) << "\n";
+    *debug << "failed posix_spawnp: " << strerror(err) << '\n';
     goto done;
   }
 
@@ -203,7 +203,7 @@ int run(const std::vector<std::string> &args, const std::string &input,
         if (r == -1) {
           if (errno == EAGAIN)
             break;
-          *debug << "failed to read from child: " << strerror(errno) << "\n";
+          *debug << "failed to read from child: " << strerror(errno) << '\n';
           goto done;
         }
 
@@ -225,7 +225,7 @@ int run(const std::vector<std::string> &args, const std::string &input,
         } while (w == -1 && errno == EINTR);
 
         if (w == -1 && errno != EAGAIN) {
-          *debug << "failed to write to child: " << strerror(errno) << "\n";
+          *debug << "failed to write to child: " << strerror(errno) << '\n';
           goto done;
         }
 
@@ -256,11 +256,11 @@ int run(const std::vector<std::string> &args, const std::string &input,
       if (WIFEXITED(status)) {
         if (WEXITSTATUS(status) != EXIT_SUCCESS)
           *debug << "child returned exit status " << WEXITSTATUS(status)
-                 << "\n";
+                 << '\n';
         break;
       }
       if (WIFSIGNALED(status)) {
-        *debug << "child exited due to signal " << WTERMSIG(status) << "\n";
+        *debug << "child exited due to signal " << WTERMSIG(status) << '\n';
         break;
       }
     }
@@ -298,7 +298,7 @@ static int __attribute__((unused)) test_process(int argc, char **argv) {
   if (argc < 2 || strcmp(argv[1], "--help") == 0 ||
       strcmp(argv[1], "-h") == 0 || strcmp(argv[1], "-?") == 0) {
     std::cerr << "Rumur Process.cc tester\n"
-              << "\n"
+              << '\n'
               << " usage: " << argv[0] << " cmd args...\n";
     return EXIT_SUCCESS;
   }
@@ -313,7 +313,7 @@ static int __attribute__((unused)) test_process(int argc, char **argv) {
   // read stdin until EOF
   std::ostringstream input;
   for (std::string line; std::getline(std::cin, line);) {
-    input << line << "\n";
+    input << line << '\n';
   }
 
   // run our designated process


### PR DESCRIPTION
A recent bug fix in the Zig compiler made me realise this code was
unnecessarily carrying open file descriptors (the source ones to the `dup2`
operations) into the child process. We can address this and simplify the whole
situation by taking advantage of the `dup2` happening _before_ exec, and thus
close-on-exec does what we need.