### PR TITLE
fix malformed generated code when complex-returning function used within guard

### DIFF
--- a/rumur/src/generate-allocations.cc
+++ b/rumur/src/generate-allocations.cc
@@ -39,6 +39,11 @@ private:
 
 } // namespace
 
+void generate_allocations(std::ostream &out, const Expr &expr) {
+  Generator g(out);
+  g.dispatch(expr);
+}
+
 void generate_allocations(std::ostream &out, const Stmt &stmt) {
   Generator g(out);
   g.dispatch(stmt);

--- a/rumur/src/generate-model.cc
+++ b/rumur/src/generate-model.cc
@@ -212,6 +212,10 @@ void generate_model(std::ostream &out, const Model &m) {
             out << ";\n";
           }
 
+          // allocate memory for any complex-returning functions we call
+          if (s->guard != nullptr)
+            generate_allocations(out, *s->guard);
+
           out << "  return ";
           if (s->guard == nullptr) {
             out << "true";

--- a/rumur/src/generate.h
+++ b/rumur/src/generate.h
@@ -13,6 +13,7 @@ int output_checker(const std::string &path, const rumur::Model &model,
                    const std::pair<ValueType, ValueType> &value_types);
 
 // Generate prelude definitions to allocate memory for function returns
+void generate_allocations(std::ostream &out, const rumur::Expr &expr);
 void generate_allocations(std::ostream &out, const rumur::Stmt &stmt);
 
 // Helper for calling the above on a body of functions

--- a/tests/return-record-in-guard.m
+++ b/tests/return-record-in-guard.m
@@ -1,0 +1,31 @@
+-- A function returning a record that is then used within a guard. This
+-- previously resulted in malformed code being emitted.
+-- https://github.com/Smattr/rumur/issues/290
+
+type
+  x_t: record
+    y : boolean;
+  end;
+
+var
+  z: boolean;
+
+function produce(): x_t; 
+var x: x_t;
+begin
+  x.y := true;
+  return x;
+end;
+
+function consume(x: x_t): boolean;
+begin
+  return x.y;
+end;
+
+startstate begin
+  z := true;
+end;
+
+rule consume(produce()) ==> begin
+  z := !z;
+end;


### PR DESCRIPTION
When the return value of a complex-returning function was used within a guard, it would be emitted as code referring to preceding declared backing storage. This was and is correct. However the backing storage it refers to was never itself being defined.

While this was a simple omission, the cause of this seems to have been an oversight in my own thinking. I was not creative enough to realise that it was possible to use a complex-returning function in this context.

Github: fixes #290 “error when chaining a function returning a record type within a rule guard”
Reported-by: Julian Pritzi