### PR TITLE
fix UB from 'posix_memalign' usage

### DIFF
--- a/rumur/resources/header.c
+++ b/rumur/resources/header.c
@@ -2254,13 +2254,9 @@ _Static_assert(sizeof(struct queue_node) == 4096,
                "incorrect queue_node size calculation");
 
 static struct queue_node *queue_node_new(void) {
-  struct queue_node *p = NULL;
+  struct queue_node *p = aligned_alloc(sizeof(*p), sizeof(*p));
 
-  int r = posix_memalign((void **)&p, sizeof(*p), sizeof(*p));
-
-  assert((r == 0 || r == ENOMEM) && "invalid alignment to posix_memalign");
-
-  if (__builtin_expect(r != 0, 0)) {
+  if (__builtin_expect(p == NULL, 0)) {
     oom();
   }
 


### PR DESCRIPTION
Casting the `struct queue_node **` to `void **` here is Undefined Behaviour. This was detected during a manual audit after encountering some compiler-identified `posix_memalign` issues in another project.¹

This is an unfortunate sharp edge of `posix_memalign` as explained by the Muslc maintainer, Rich Felker, in a Stack Overflow answer:²

```
  …this is a _classic anti-pattern_ in C, and one which should be burned with
  fire. It appears in:
  …
  2. Allocation functions that shun the standard C idiom of returning `void *` (which doesn't suffer from this issue because it involves a _value conversion_ instead of _type punning_), instead returning an error flag and storing the result via a pointer-to-pointer. … For (2), both cudaMalloc and posix_memalign are examples.

  In neither case does the interface inherently _require_ invalid usage, but it
  strongly encourages it, and admits correct usage only with an extra temporary
  object of type `void *` that defeats the purpose of the free-and-null-out
  functionality, and makes allocation awkward.
```

¹ https://github.com/Smattr/passwand/commit/6c5fd90aef6d0d4f22b1b1177e4019d5109f1c70
² https://stackoverflow.com/questions/58809360/why-is-this-claimed-dereferencing-type-punned-pointer-warning-compiler-specific