### PR TITLE
fix sandboxed execution on Linux aarch64 with THP

### DIFF
--- a/rumur/resources/header.c
+++ b/rumur/resources/header.c
@@ -266,6 +266,10 @@ static void sandbox(void) {
         BPF_JUMP(BPF_JMP | BPF_JEQ | BPF_K, __NR_munmap, 0, 1),
         BPF_STMT(BPF_RET | BPF_K, SECCOMP_RET_ALLOW),
 #endif
+#ifdef __NR_madvise
+        BPF_JUMP(BPF_JMP | BPF_JEQ | BPF_K, __NR_madvise, 0, 1),
+        BPF_STMT(BPF_RET | BPF_K, SECCOMP_RET_ALLOW),
+#endif
 
     /* If we're running multithreaded, enable syscalls used by pthreads. */
 #ifdef __NR_clone
@@ -290,11 +294,6 @@ static void sandbox(void) {
 #endif
 #ifdef __NR_get_robust_list
         BPF_JUMP(BPF_JMP | BPF_JEQ | BPF_K, __NR_get_robust_list, 0, 1),
-        BPF_STMT(BPF_RET | BPF_K,
-                 THREADS > 1 ? SECCOMP_RET_ALLOW : SECCOMP_RET_TRAP),
-#endif
-#ifdef __NR_madvise
-        BPF_JUMP(BPF_JMP | BPF_JEQ | BPF_K, __NR_madvise, 0, 1),
         BPF_STMT(BPF_RET | BPF_K,
                  THREADS > 1 ? SECCOMP_RET_ALLOW : SECCOMP_RET_TRAP),
 #endif


### PR DESCRIPTION
To detect whether Transparent Huge Pages (THP) are enabled on 64-bit ARM, system
allocation routines read /sys/kernel/mm/transparent_hugepage/enabled using
`openat`. Description from Emanuele Rocca:

>  rumur fails to build from source on arm64 when using glibc 2.43, currently in
  experimental…
  The cause for the above failures is that the seccomp sandbox stops the
  attempted open of /sys/kernel/mm/transparent_hugepage/enabled:
>
>```
>  E       AssertionError: model failed: …
>  [...]
>  E         openat(AT_FDCWD, "/sys/kernel/mm/transparent_hugepage/enabled", O_RDONLY) = -1 ENETDOWN (Network is down)
>  E         --- SIGSYS {si_signo=SIGSYS, si_code=SYS_SECCOMP, si_call_addr=0xe3ac16e98c60, si_syscall=__NR_openat, si_arch=AUDIT_ARCH_AARCH64} ---
>  E         +++ killed by SIGSYS (core dumped) +++
>```
>
>  One possible solution would be updating the seccomp filter to allow the
  action above, but perhaps more discussion with glibc upstream is needed
  to see if there are alternatives to opening a file under /sys, which can
  cause problems in other scenarios too.

In the process of debugging this, Glibc made the decision to change to using
`madvise` instead of reading /sys/kernel/mm/transparent_hugepage/enabled to
detect THP. This resolves the `openat` failure within the sandbox, but now
incurs an `madvise` regardless if we are multithreaded or not. So this change
allows `madvise` unconditionally in the sandbox.

Commentary from Matthew Fernandez:

>  Unconditionally adding `madvise` as an allowable call does not meaningfully
  expand the attack surface as I am not aware of anything security-relevant you
  can do with `madvise`.
>
>  Particular praise to Aurélien’s thoroughness here. Rather than tweaking the
  location where `madvise` was conditionally allowed, Aurélien identified that
  semantically this now belongs earlier, with the syscalls we are enabling due
  to malloc’s actions. This kind of careful attention to detail is what saves
  churn and countless downstream merge conflicts.

¹ https://inbox.sourceware.org/libc-alpha/PAWPR08MB8982EEFF3D3C7A2B3DB803D68373A@PAWPR08MB8982.eurprd08.prod.outlook.com/

Debian: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1128916
Reported-by: Emanuele Rocca <ema@debian.org>
Tested-by: Aurélien Jarno <aurel32@debian.org>