### PR TITLE
CI: upgrade Linux GCC 15.1 → 15.2

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -85,20 +85,20 @@ task:
         CXXFLAGS: -pedantic -Werror -Wno-error=overloaded-virtual -g -fno-omit-frame-pointer -fsanitize=address,undefined -fno-sanitize-recover=undefined
         UBSAN_OPTIONS: print_stacktrace=1
       install_script: apt-get update -y && apt-get install --no-install-recommends -y bison cmake libfl-dev libgmp-dev libxml2-utils python3-pytest strace z3
-    - name: Linux, GCC 15.1
+    - name: Linux, GCC 15.2
       container:
-        image: gcc:15.1
+        image: gcc:15.2
       environment:
         DEBIAN_FRONTEND: noninteractive
-        CXXFLAGS: -pedantic -Werror -Wno-error=overloaded-virtual -g -fno-omit-frame-pointer -fsanitize=address,undefined -fno-sanitize-recover=undefined -fuse-ld=gold
+        CXXFLAGS: -pedantic -Werror -Wno-error=overloaded-virtual -g -fno-omit-frame-pointer -fsanitize=address,undefined -fno-sanitize-recover=undefined
         UBSAN_OPTIONS: print_stacktrace=1
       install_script: apt-get update -y && apt-get install --no-install-recommends -y bison cmake libfl-dev libgmp-dev libxml2-utils python3-pytest strace z3
-    - name: Linux, ARM, GCC 15.1
+    - name: Linux, ARM, GCC 15.2
       arm_container:
-        image: gcc:15.1
+        image: gcc:15.2
       environment:
         DEBIAN_FRONTEND: noninteractive
-        CXXFLAGS: -pedantic -Werror -Wno-error=overloaded-virtual -g -fsanitize=address,undefined -fno-sanitize-recover=undefined -fuse-ld=gold
+        CXXFLAGS: -pedantic -Werror -Wno-error=overloaded-virtual -g -fsanitize=address,undefined -fno-sanitize-recover=undefined
         UBSAN_OPTIONS: print_stacktrace=1
       install_script: apt-get update -y && apt-get install --no-install-recommends -y bison cmake libfl-dev libgmp-dev libxml2-utils python3-pytest strace z3
 


### PR DESCRIPTION
As per bd92714320d95317adf690826529a325f14d9269, we should be able to upgrade these jobs by removing use of the Gold linker that is not installed in the newer images.