### PR TITLE
fix: ignore '$TMPDIR' when it is an unusable directory

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -303,6 +303,8 @@ jobs:
       - run: sudo add-apt-repository ppa:ubuntu-toolchain-r/test
       - run: sudo apt-get update
       - run: sudo apt-get install --no-install-recommends -y g++-15 libfl-dev libxml2-utils python3-pytest
+      - run: which gcc-15
+      - run: which g++-15
       - run: echo "cloning ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}"
       - run: git clone --no-checkout -- ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY} wd
       - run: cd wd && git fetch -- origin ${{ github.event.pull_request.head.sha }} && git checkout FETCH_HEAD
@@ -327,6 +329,8 @@ jobs:
       - run: sudo add-apt-repository ppa:ubuntu-toolchain-r/test
       - run: sudo apt-get update
       - run: sudo apt-get install --no-install-recommends -y g++-16 libfl-dev libxml2-utils python3-pytest
+      - run: which gcc-16
+      - run: which g++-16
       - run: echo "cloning ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}"
       - run: git clone --no-checkout -- ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY} wd
       - run: cd wd && git fetch -- origin ${{ github.event.pull_request.head.sha }} && git checkout FETCH_HEAD
@@ -418,6 +422,8 @@ jobs:
       - run: sudo add-apt-repository ppa:ubuntu-toolchain-r/test
       - run: sudo apt-get update
       - run: sudo apt-get install --no-install-recommends -y g++-15 libfl-dev libxml2-utils python3-pytest
+      - run: which gcc-15
+      - run: which g++-15
       - run: echo "cloning ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}"
       - run: git clone --no-checkout -- ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY} wd
       - run: cd wd && git fetch -- origin ${{ github.event.pull_request.head.sha }} && git checkout FETCH_HEAD

--- a/common/help.c
+++ b/common/help.c
@@ -21,7 +21,7 @@ int help(const unsigned char *manpage, size_t manpage_len) {
 
   // find temporary storage space
   const char *TMPDIR = getenv("TMPDIR");
-  if (TMPDIR == NULL)
+  if (TMPDIR == NULL || access(TMPDIR, R_OK | W_OK | X_OK) != 0)
     TMPDIR = "/tmp";
 
   // create a temporary path


### PR DESCRIPTION
A recent audit of Ubuntu’s Rust utilities¹ led me to learn that `$TMPDIR` is only intended to be used when the directory it points to is accessible:²

> If applications are written to use temporary or intermediate files,
  they should use the _TMPDIR_ environment variable, if it is set and
  represents an accessible directory, to select the location of
  temporary files.

The effect of this change is that `rumur --help` with an unusable `$TMPDIR` set will now fall back to using /tmp instead of trying (and failing) to use this `$TMPDIR`.

¹ https://discourse.ubuntu.com/t/an-update-on-rust-coreutils/80773
² https://pubs.opengroup.org/onlinepubs/9799919799/utilities/V3_chap01.html