### PR TITLE
suppress warning from unreachable over-shift

### DIFF
--- a/rumur/resources/header.c
+++ b/rumur/resources/header.c
@@ -3575,11 +3575,9 @@ restart:
          * by the number of possible states based on how many bits we are using
          * to represent the state data.
          */
-        if (STATE_SIZE_BITS < sizeof(size_t) * CHAR_BIT) {
-          assert(*count <= ((size_t)1) << STATE_SIZE_BITS &&
-                 "seen set size "
-                 "exceeds total possible number of states");
-        }
+        assert((STATE_SIZE_BITS >= sizeof(size_t) * CHAR_BIT ||
+                *count <= ((size_t)1) << STATE_SIZE_BITS) &&
+               "seen set size exceeds total possible number of states");
 
         /* Update statistics if `--trace memory_usage` is in effect. Note that
          * we do this here (when a state is being added to the seen set) rather


### PR DESCRIPTION
When debugging is enabled and the state is of non-trivial size, GCC complains about this code:

```
  In file included from foo.c:7:
  foo.c: In function ‘set_insert’:
  foo.c:3802:40: warning: left shift count >= width of type
    [-Wshift-count-overflow]
   3802 |           assert(*count <= ((size_t)1) << STATE_SIZE_BITS &&
        |                                        ^~
```

Reported-by: GCC 15.2.1 -Wshift-count-overflow