### PR TITLE
CI: suppress -Wdeprecated-literal-operator failures on macOS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -437,7 +437,7 @@ jobs:
     runs-on: macos-26-intel
     env:
       CFLAGS: -pedantic -Werror -g -fno-omit-frame-pointer -fsanitize=address,undefined -fno-sanitize-recover=address,undefined
-      CXXFLAGS: -pedantic -Werror -Wno-error=overloaded-virtual -g -fno-omit-frame-pointer -fsanitize=address,undefined -fno-sanitize-recover=address,undefined
+      CXXFLAGS: -pedantic -Werror -Wno-error=deprecated-literal-operator -Wno-error=overloaded-virtual -g -fno-omit-frame-pointer -fsanitize=address,undefined -fno-sanitize-recover=address,undefined
       UBSAN_OPTIONS: print_stacktrace=1
     steps:
       - run: uname -rms
@@ -463,7 +463,7 @@ jobs:
     runs-on: macos-26-intel
     env:
       CFLAGS: -pedantic -Werror -g -fno-omit-frame-pointer -fsanitize=address,undefined -fno-sanitize-recover=address,undefined
-      CXXFLAGS: -pedantic -Werror -Wno-error=overloaded-virtual -g -fno-omit-frame-pointer -fsanitize=address,undefined -fno-sanitize-recover=address,undefined
+      CXXFLAGS: -pedantic -Werror -Wno-error=deprecated-literal-operator -Wno-error=overloaded-virtual -g -fno-omit-frame-pointer -fsanitize=address,undefined -fno-sanitize-recover=address,undefined
       UBSAN_OPTIONS: print_stacktrace=1
     steps:
       - run: uname -rms
@@ -485,7 +485,7 @@ jobs:
     runs-on: macos-26-intel
     env:
       CFLAGS: -pedantic -Werror -g -fno-omit-frame-pointer -fsanitize=address,undefined -fno-sanitize-recover=address,undefined
-      CXXFLAGS: -pedantic -Werror -Wno-error=overloaded-virtual -g -fno-omit-frame-pointer -fsanitize=address,undefined -fno-sanitize-recover=address,undefined
+      CXXFLAGS: -pedantic -Werror -Wno-error=deprecated-literal-operator -Wno-error=overloaded-virtual -g -fno-omit-frame-pointer -fsanitize=address,undefined -fno-sanitize-recover=address,undefined
       UBSAN_OPTIONS: print_stacktrace=1
     steps:
       - run: uname -rms


### PR DESCRIPTION
There is a C++11 defect report about a deprecated syntax for user-defined literals¹ that compilers seem to have mostly ignored before now. The macOS images seem to now pull in Clang 21 that warns about this, failing compilation:

```
  [  4%] Building CXX object librumur/CMakeFiles/librumur.dir/src/Boolean.cc.o
  In file included from rumur/rumur/wd/librumur/src/Boolean.cc:4:
  In file included from rumur/rumur/wd/librumur/include/rumur/Boolean.h:5:
  In file included from rumur/rumur/wd/librumur/include/rumur/Expr.h:6:
  /usr/local/include/gmpxx.h:2163:29: error: identifier '_mpz' preceded by
    whitespace in a literal operator declaration is deprecated
    [-Werror,-Wdeprecated-literal-operator]
   2163 | inline mpz_class operator"" _mpz(const char* s)
        |                  ~~~~~~~~~~~^~~~
        |                  operator""_mpz
  /usr/local/include/gmpxx.h:2168:29: error: identifier '_mpq' preceded by
    whitespace in a literal operator declaration is deprecated
    [-Werror,-Wdeprecated-literal-operator]
   2168 | inline mpq_class operator"" _mpq(const char* s)
        |                  ~~~~~~~~~~~^~~~
        |                  operator""_mpq
  /usr/local/include/gmpxx.h:2175:29: error: identifier '_mpf' preceded by
    whitespace in a literal operator declaration is deprecated
    [-Werror,-Wdeprecated-literal-operator]
   2175 | inline mpf_class operator"" _mpf(const char* s)
        |                  ~~~~~~~~~~~^~~~
        |                  operator""_mpf
  3 errors generated.
```

There are a number of things I do not understand about this:
  1. The GMP include directories are added as `SYSTEM`, so we should not be seeing compiler warnings from their headers.
  2. Of the 4 macOS jobs, the macOS+Macports+aarch64 is somehow not affected by this despite seemingly using the same compiler and GMP version.

The work arounds elsewhere on the internet are pretty unpleasant,² so lets do some targeted -Werror disabling instead.

¹ https://cplusplus.github.io/CWG/issues/2521.html
² https://github.com/SRI-CSL/libpoly/pull/110

Gitlab: https://github.com/cvc5/cvc5-rs/issues/56
Reported-by: AppleClang 21.0.0.21000101 -Wdeprecated-literal-operator