### PR TITLE
fix name of boolean constants located during symbol lookup

### DIFF
--- a/librumur/src/resolve-symbols.cc
+++ b/librumur/src/resolve-symbols.cc
@@ -41,10 +41,9 @@ public:
     symtab.declare("boolean", td);
     mpz_class index = 0;
     for (const std::pair<std::string, location> &m : Boolean->members) {
-      symtab.declare(m.first,
-                     Ptr<ConstDecl>::make("boolean",
-                                          Ptr<Number>::make(index, location()),
-                                          Boolean, location()));
+      symtab.declare(m.first, Ptr<ConstDecl>::make(
+                                  m.first, Ptr<Number>::make(index, location()),
+                                  Boolean, location()));
       index++;
     }
   }


### PR DESCRIPTION
Both `false` and `true` were incorrectly created as constants named “boolean” during symbol resolution. They were registered in the resolution table under their correct names, so symbol resolution worked out. But if you inspected the AST data structures you would find literal expressions “false” and “true” would be described as pointing to values named “boolean”.

Github: fixes #342 “symbol resolution calls 'true' and 'false' instead 'boolean'”