### PR TITLE
when possible, suppress build paths in Bison-generated files

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -588,3 +588,21 @@ jobs:
           cd wd &&
           git ls-files -z -- ':(glob)**/CMakeLists.txt' ':(glob)**/*.cmake' |
           xargs -0 -- python3 -m cmakelang.lint
+
+  python_analysis:
+    name: Python analysis
+    runs-on: ubuntu-26.04
+    steps:
+      - run: uname -rms
+      - run: python3 --version
+      - run: python3 -m pip install --user isort
+      - run: echo "cloning ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}"
+      - run: git clone --no-checkout -- ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY} wd
+      - run: >
+          cd wd &&
+          git fetch -- origin ${{ github.event.pull_request.head.sha }} &&
+          git checkout FETCH_HEAD
+      - run: >
+          cd wd &&
+          git ls-files -z -- ':(glob)**/*.py' |
+          xargs -0 -- python3 -m isort --profile=black --

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -570,3 +570,21 @@ jobs:
       - run: >
           cd wd && git ls-files -z -- '**/*.c' '**/*.cc' '**/*.h' |
           xargs -0 -- clang-format-22 --dry-run --style=file --Werror --
+
+  cmake_analysis:
+    name: CMake analysis
+    runs-on: ubuntu-26.04
+    steps:
+      - run: uname -rms
+      - run: python3 --version
+      - run: python3 -m pip install --user cmakelang
+      - run: echo "cloning ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}"
+      - run: git clone --no-checkout -- ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY} wd
+      - run: >
+          cd wd &&
+          git fetch -- origin ${{ github.event.pull_request.head.sha }} &&
+          git checkout FETCH_HEAD
+      - run: >
+          cd wd &&
+          git ls-files -z -- ':(glob)**/CMakeLists.txt' ':(glob)**/*.cmake' |
+          xargs -0 -- python3 -m cmakelang.lint

--- a/doc/toy-model-checker.py
+++ b/doc/toy-model-checker.py
@@ -12,6 +12,7 @@ understanding ../rumur/resources/header.c.
 import sys
 from typing import Optional, Set
 
+
 class State(object):
 
   def __init__(self, value: int = 0, previous: Optional["State"] = None):

--- a/librumur/CMakeLists.txt
+++ b/librumur/CMakeLists.txt
@@ -1,4 +1,20 @@
 find_package(BISON REQUIRED)
+if(BISON_VERSION VERSION_GREATER_EQUAL "3.7.1")
+  # we have a recent enough Bison to support `--file-prefix-map=…`
+  if(CMAKE_CURRENT_BINARY_DIR MATCHES " " OR
+     CMAKE_CURRENT_BINARY_DIR MATCHES "=")
+    # The build path contains characters that will be misinterpreted in
+    # `--file-prefix-map=…`. Thus we cannot achieve a reproducible build.
+    set(PREFIX_MAP "")
+  else()
+    # suppress build paths in generated files
+    set(PREFIX_MAP "--file-prefix-map=${CMAKE_CURRENT_BINARY_DIR}= ")
+  endif()
+else()
+  # we do not have a recent enough Bison to support `--file-prefix-map=…`
+  set(PREFIX_MAP "")
+endif()
+message(STATUS "Bison prefix map option: ${PREFIX_MAP}")
 find_package(FLEX REQUIRED)
 
 find_path(GMPXX_INCLUDE NAMES gmpxx.h PATHS ENV CPLUS_INCLUDE_PATH)
@@ -17,7 +33,7 @@ endif()
 bison_target(parser
   src/parser.yy
   ${CMAKE_CURRENT_BINARY_DIR}/parser.yy.cc
-  COMPILE_FLAGS "--no-lines --warnings=all")
+  COMPILE_FLAGS "${PREFIX_MAP}--no-lines --warnings=all")
 flex_target(lexer
   src/lexer.l
   ${CMAKE_CURRENT_BINARY_DIR}/lexer.l.cc


### PR DESCRIPTION
Build paths in Bison-generated files has been a barrier to reproducible builds, pointed out by Debian Developers many times over the past years. It has never seemed worth fixing this because a bug in Flex made the build not reproducible anyway. In my mind, I actually incorrectly conflated the Flex bug as the _root cause_ of the Bison problem due to this situation having persisted for so long.

The Flex bug has now been fixed in Flex commit
cff048484c75ba2f434b69caa8df1c2bbe12d366. Though this has not yet made it into a Flex release, it seems a good time to fix our interactions with Bison such that we should automatically acquire reproducible builds when the Flex fix propagates to Debian.