### PR TITLE
tighten bounds of the type of a numeric literal

### DIFF
--- a/librumur/src/Number.cc
+++ b/librumur/src/Number.cc
@@ -35,7 +35,8 @@ void Number::visit(ConstBaseTraversal &visitor) const {
 bool Number::constant() const { return true; }
 
 Ptr<TypeExpr> Number::type() const {
-  return Ptr<Range>::make(nullptr, nullptr, location());
+  const Ptr<Number> bound = Ptr<Number>::make(value, location());
+  return Ptr<Range>::make(bound, bound, location());
 }
 
 mpz_class Number::constant_fold() const { return value; }


### PR DESCRIPTION
This is believed to have no effect for now. Its primary utility is for speculative future work where we may change how the `coerces_to` logic works.

Github: closes #337 “tightly bound 'Number'’s type”