### PR TITLE
fix mismatched 'open_scope'/'close_scope' when SMT-simplifying

### DIFF
--- a/rumur/src/smt/simplify.cc
+++ b/rumur/src/smt/simplify.cc
@@ -235,7 +235,7 @@ public:
       if (auto f = dynamic_cast<Function *>(c.get()))
         declare_func(*f);
     }
-    solver->open_scope();
+    solver->close_scope();
   }
 
   void visit_mul(Mul &n) final { visit_bexpr(n); }


### PR DESCRIPTION
I believe this had no visible effect, because nothing is ever written to the solver after the second `open_scope`. But still this appears to have been a typo.

Github: fixes #346 “SMT simplification appears to end with an open scope”